### PR TITLE
add enable_output option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,11 +52,8 @@ resource "azurerm_template_deployment" "resource" {
             "tags": "[json(parameters('tags'))]"
         }
     ],
-    "outputs": {
-        "id": {
-            "type": "string",
-            "value": "[resourceId('${var.type}', parameters('name'))]"
-        }    
+ "outputs": {
+        ${var.enable_output? "\"id\": { \"type\": \"string\",\"value\": \"[resourceId('${var.type}', parameters('name'))]\"        }": ""}
     }
 }
 DEPLOY

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,8 @@ variable "tags" {
 variable "type" {
   description = "Type of the resource. This value is a combination of the namespace of the resource provider and the resource type (such as Microsoft.Storage/storageAccounts)."
 }
+
+variable "enable_output" {
+  description = "Disable output collection for resources that doesn't support it"
+  default     = false
+}


### PR DESCRIPTION
Some resources (like cosmos containers) don't like the output id, reported error is:

"Unable to evaluate template outputs: 'id'